### PR TITLE
[FEATURE] Add event to fetch custom error messages

### DIFF
--- a/Classes/Event/TranslateErrorMessageEvent.php
+++ b/Classes/Event/TranslateErrorMessageEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the hcaptcha extension for TYPO3
+ * - (c) 2021 waldhacker UG (haftungsbeschränkt)
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Waldhacker\Hcaptcha\Event;
+
+final class TranslateErrorMessageEvent
+{
+    protected string $errorCode = '';
+
+    protected string $message = '';
+
+    public function __construct(string $errorCode)
+    {
+        $this->errorCode = $errorCode;
+    }
+
+    public function getErrorCode(): string
+    {
+        return $this->errorCode;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function setMessage(string $message): void
+    {
+        $this->message = $message;
+    }
+}

--- a/Classes/Validation/HcaptchaValidator.php
+++ b/Classes/Validation/HcaptchaValidator.php
@@ -19,11 +19,13 @@ declare(strict_types=1);
 namespace Waldhacker\Hcaptcha\Validation;
 
 use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\HttpUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator;
+use Waldhacker\Hcaptcha\Event\TranslateErrorMessageEvent;
 use Waldhacker\Hcaptcha\Service\ConfigurationService;
 
 class HcaptchaValidator extends AbstractValidator
@@ -109,7 +111,9 @@ class HcaptchaValidator extends AbstractValidator
      */
     protected function translateErrorMessage($translateKey, $extensionName, $arguments = []): string
     {
-        return LocalizationUtility::translate(
+        $event = new TranslateErrorMessageEvent($translateKey);
+        GeneralUtility::makeInstance(EventDispatcher::class)->dispatch($event);
+        return $event->getMessage() ?: LocalizationUtility::translate(
             $translateKey,
             $extensionName,
             $arguments


### PR DESCRIPTION
This PR adds an event that allows other extensions to customize error messages.

The implementation is done as a part of University of Basel internal project.